### PR TITLE
Fix infinite loop during linking on ARM

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -570,7 +570,7 @@ extcoff: $(TARGET).elf
 .PRECIOUS : $(OBJ)
 %.elf: $(OBJ)
 	@echo $(MSG_LINKING) $@
-	$(CC) $(ALL_CFLAGS) $^ --output $@ $(LDFLAGS)
+	$(CC) $(patsubst -Wa%.o,,$(ALL_CFLAGS)) $^ --output $@ $(LDFLAGS)
 
 
 # Compile: create object files from C source files.


### PR DESCRIPTION
Presence of the assembler option in the link call already somewhat broke compilation before (as midi.o was being replaced by assembler output). On ARM with GCC12, it produces an infinite loop. Remove the flag as it does not do anything sensible here.